### PR TITLE
Fix for false warning "Missing resource string: 'undefined'"

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
           "type": "array",
           "default": [
             "translate=\"([A-Za-z0-9_]+)\"",
-            "{{'([A-Za-z0-9_]+)' \\| translate }}"
+            "{{ *'([A-Za-z0-9_]+)' *\\| *translate *}}"
           ],
           "description": "Regular expressions used to locate translation string/keys within documents.",
           "required": true

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
           "type": "array",
           "default": [
             "translate=\"([A-Za-z0-9_]+)\"",
-            "{{'([A-Za-z0-9_]+)' | translate }}"
+            "{{'([A-Za-z0-9_]+)' \\| translate }}"
           ],
           "description": "Regular expressions used to locate translation string/keys within documents.",
           "required": true


### PR DESCRIPTION
Escaped pipe character in Regex pattern to prevent it being interpreted as OR
This commit fixes issue #5 